### PR TITLE
fix(publish): access for publishing user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/paperspace-client-sdk/.npmrc
       - run:
           name: Publish package
-          command: npm publish
+          command: npm publish --access=public
 
 workflows:
   version: 2

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "NODE_ENV=development webpack --progress --config webpack.config.js",
     "dist": "NODE_ENV=production webpack --progress --config webpack.config.js",
     "preversion": "yarn test && yarn dist && git add dist -f",
-    "postversion": "git push origin :refs/tags/v\"$npm_package_version\" && git push && echo \"✨ Successfully released version v$npm_package_version! The tag build process will publish it ✨\""
+    "postversion": "git push origin \"$npm_package_version\" && git push && echo \"✨ Successfully released version v$npm_package_version! The tag build process will publish it ✨\""
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",


### PR DESCRIPTION
This PR makes it so that CircleCI has access to publish the package correctly and that only the created tag is pushed to master 