### PR TITLE
chore(README): update publish version docs to be more bullet point driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,73 +6,73 @@ Paperspace SDK for client-side browser environments
 
 The module is published as a node_module under the same name [`@paperspace/client-sdk`](https://www.npmjs.com/package/@paperspace/client-sdk) on [NPM](www.npmjs.com). You can install it like so:
 
-```
-yarn add @paperspace/client-sdk
+```sh
+$ yarn add @paperspace/client-sdk
 ```
 
 ## Run example
 
 This will run the build and serve an example page with some examples on it:
 
-```
-yarn
-yarn start
+```sh
+$ yarn
+$ yarn start
 ```
 
 ## Build for development
 
 If you are developing this repository in conjunction with another or just want to test it as you develop, you can preferrably run the development build, which gives you a version that is easier to debug:
 
-```
-yarn
-yarn dev
+```sh
+$ yarn
+$ yarn build:dev
 ```
 
 ## Build for production
 
 If you are looking to try out the production build, you can run the production build like this:
 
-```
-yarn
-yarn dist
+```sh
+$ yarn
+$ yarn build:prod
 ```
 
 ## Developing in conjunction with another repository
 
 If you are developing this repository in conjunction with another, you can [`yarn link`](https://yarnpkg.com/lang/en/docs/cli/link/) your local version of the @paperspace/client-sdk into the host repository:
 
+```sh
+$ yarn link # In a separate terminal window from your (development) build
 ```
-yarn link
-```
-
-Remember to run a build, probably the development build, to populate the `dist` folder, so the host repository have files to link!
 After this, you want to run `yarn link @paperspace/client-sdk` in the host repository to activate it.
 
-**NB**: Once you are done developing @paperspace/client-sdk remember to run `yarn unlink @paperspace/client-sdk` in the host repository and `yarn unlink` in the root of this repository! This link will stay active, even if you switch branches or pull the latest changes until you unlink them.
+**NB**: Remember to `yarn unlink @paperspace/client-sdk` in the host repository and `yarn unlink` in the root of this repository when you are done developing client-sdk! This link will otherwise stay active, even if you switch branches or pull changes.
 
 **NBB**: Yarn does not work very well with passphrase prompts - [it basically ignores them](https://github.com/yarnpkg/yarn/issues/3699) - so if you use that for you ssh-key, please use [`ssh-add`](https://www.ssh.com/ssh/add) to remember your authentication for the given session.
 
 ## Publish a new version
 
-This repository is set up to publish a new version on a new tag. To publish a new version, first pull latest changes from development, and checkout a new release branch, where `<new-version>` is the new version you are about to publish. If you are not quite sure about your change yet you can use a [pre-release version](https://semver.org/#spec-item-9) before you release an actual version change:
-```
+This repository is set up to *publish a new version on a new tag*. To publish a new version follow these steps, where `X.Y.Z` is the new version you are about to publish:
+
+*Pro-tip*: use `--patch`, `--minor` or `--major` flags for `yarn version` to automatically increment the version. You can also use a [pre-release version](https://semver.org/#spec-item-9) before you release an actual version change.
+
+```sh
 $ git pull --rebase
-$ git checkout -b release_v<new-version>
-```
-
-After this run `yarn version` (pro-tip: use `--patch`, `--minor` or `--major` flags to automatically increment the version) and type in the new version:
-```
-$ yarn version
+$ git checkout -b release_vX.Y.Z
+$ yarn version # This will create a tag, run `preversion` and `postversion` scripts and push the tag to remote
 info Current version: 1.0.0
-question New version: <new-version> # Do not prefix with 'v'!
+question New version: X.Y.Z # Do not prefix with 'v'!
 ...
-✨ Successfully released version v<new-version>! The tag build process will publish it ✨
+✨ Successfully released version vX.Y.Z! The tag build process will publish it ✨
 ```
-Yarn will run `preversion` and `postversion` scripts to commit the version change and the new tag. CircleCI will pick up on the newly created tag and automatically publish the version.
+CircleCI will pick up on the newly created tag and automatically publish the version.
 
-Be sure to create a pull request to merge your version change back into development!
-
-That's it! Now you can install it with either `yarn add @paperspace/client-sdk@latest` or `yarn add @paperspace/client-sdk@<new-version>`.
+Now push your branch to remote and create a PR to see the status of the publish build and get your version change merged back into development:
+```sh
+$ git push --set-upstream origin release_vX.Y.Z
+$ open https://github.com/Paperspace/PS_H264STREAM/compare/release_vX.Y.Z
+```
+That's it! You can now install this module with either `yarn add @paperspace/client-sdk@latest` or `yarn add @paperspace/client-sdk@X.Y.Z`.
 
 **NB**: Even if the version number is lower than a previously released version, it will be installed as the latest version!
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "eslint .",
     "dev": "NODE_ENV=development webpack --progress --config webpack.config.js",
     "dist": "NODE_ENV=production webpack --progress --config webpack.config.js",
-    "postversion": "git push origin refs/tags/v\"$npm_package_version\" && git push && echo \"✨ Successfully released version v$npm_package_version! The tag build process will publish it ✨\"",
+    "postversion": "git push origin refs/tags/v\"$npm_package_version\" && echo \"✨ Successfully released version v$npm_package_version! The tag build process will publish it ✨\"",
     "prettier": "prettier --single-quote --write src/**/*.js"
   },
   "engines": {


### PR DESCRIPTION
This PR updates the docs to be more bullet point driven for the version publish flow.

It also moves the branch push to a manual command to make it more intuitive.